### PR TITLE
update pkg name

### DIFF
--- a/dotnet-autorest-createproject/Views/ProjectFile.cshtml
+++ b/dotnet-autorest-createproject/Views/ProjectFile.cshtml
@@ -7,7 +7,7 @@
     <TargetFrameworks>@String.Join(';', Model.TFMs)</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageId>eShopWorld.@(Model.ProjectName).Client</PackageId>
+    <PackageId>Esp.@(Model.ProjectName).Client</PackageId>
     <Version>@Model.Version</Version>
     <Authors>eShopWorld</Authors>
     <Company>eShopWorld</Company>


### PR DESCRIPTION
#[89389](https://dev.azure.com/eshopworld/evo-core/_workitems/edit/89389)

Pipeline is expecting that pkg name is generated with `ESP` prefix instead of `eShopworld`

This PR updates the pkg name so pipeline succeeds on pushing autorest generated pkg