### PR TITLE
added suffix to the dll name to ensure there's no clash with the sut dll name if they need to be referenced

### DIFF
--- a/dotnet-autorest-createproject.tests/SwaggerJSONParserTests.cs
+++ b/dotnet-autorest-createproject.tests/SwaggerJSONParserTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Xunit;
 
 namespace ESW.autorest.createProject.tests
@@ -6,6 +7,38 @@ namespace ESW.autorest.createProject.tests
     // ReSharper disable once InconsistentNaming
     public class SwaggerJSONParserTests
     {
+        [Theory, Trait("Category", "Unit")]
+        [InlineData(@"
+        {
+            ""info"": {
+                ""title"": ""My.Api.Service"",
+                ""version"": ""1.5""
+            }
+        }", null, "My.Api.Service.AutoRestClient", "1.5")]
+        [InlineData(@"
+        {
+            ""info"": {
+                ""title"": ""My.Api.Service"",
+                ""version"": ""1.5""
+            }
+        }", "2.0", "My.Api.Service.AutoRestClient", "2.0")]
+        public void ExtractMetadataInternal_Passes(string swaggerContents, string autoRestPackageVersion, string expectedProjectName, string expectedProjectVersion)
+        {
+            var (projectName, projectVersion) = SwaggerJsonParser.ExtractMetadataInternal(swaggerContents, autoRestPackageVersion);
+
+            projectName.Should().Be(expectedProjectName);
+            projectVersion.Should().Be(expectedProjectVersion);
+        }
+        
+        [Theory, Trait("Category", "Unit")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ExtractMetadataInternal_Fails(string swaggerContents)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                SwaggerJsonParser.ExtractMetadataInternal(swaggerContents, string.Empty));
+        }        
+        
         [Theory, Trait("Category", "Unit")]
         [InlineData("v1", "1")]
         [InlineData("v1.3", "1.3")]

--- a/dotnet-autorest-createproject.tests/dotnet-autorest-createproject.tests.csproj
+++ b/dotnet-autorest-createproject.tests/dotnet-autorest-createproject.tests.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>ESW.autorest.createProject.tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet-autorest-createproject/dotnet-autorest-createproject.csproj
+++ b/dotnet-autorest-createproject/dotnet-autorest-createproject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <StartupObject>ESW.autorest.createProject.Runner</StartupObject>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -14,6 +14,7 @@
     <Description>autorest backed client side library generator for APIs exposing swagger metadata</Description>
     <PackageId>eShopWorld.AutoRest.CreateProject</PackageId>
     <Authors>Oisin Haken</Authors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When using this in an integration test project we can't reference both the SUT and the autorest dll since their name matches.

Converted to .NET 6 given this version is not supported anymore